### PR TITLE
🐠 Make Config reusable in non-static context

### DIFF
--- a/src/main/java/edu/phema/elm_to_omop/helper/Config.java
+++ b/src/main/java/edu/phema/elm_to_omop/helper/Config.java
@@ -14,11 +14,11 @@ import java.util.logging.Logger;
  * arguments.  If not present, then pulls them from configuration file.
  * Config file is must be located in the config directory and named config.properties.
  */
-public final class Config  {
+public final class Config {
     /**
      *  Logs messages to file.
      */
-    private static final Logger LOGGER = Logger.getLogger(Config.class.getName());
+    private final Logger LOGGER = Logger.getLogger(Config.class.getName());
 
     /**
      * Configuration file name.
@@ -33,22 +33,22 @@ public final class Config  {
      */
     private Properties configProps;
 
-    private static final String PHENOTYPE_NAME_DELIMITER = "\\|";
+    private final String PHENOTYPE_NAME_DELIMITER = "\\|";
 
 
-    private static String omopBaseURL;
+    private String omopBaseURL;
 
-    private static String inputFileName;
+    private String inputFileName;
 
-    private static String vsFileName;
+    private String vsFileName;
 
-    private static String outFileName;
+    private String outFileName;
 
-    private static String source;
+    private String source;
 
-    private static String tab;
+    private String tab;
 
-    private static List<String> phenotypeExpressions;
+    private List<String> phenotypeExpressions;
 
     /**
      * Constructor finds the working directory and loads the configuration properties.
@@ -106,31 +106,31 @@ public final class Config  {
         runPropertyCheck();
     }
 
-    public static String getOmopBaseUrl() {
+    public String getOmopBaseUrl() {
         return omopBaseURL;
     }
 
-    public static String getInputFileName() {
+    public String getInputFileName() {
         return inputFileName;
     }
 
-    public static String getVsFileName() {
+    public String getVsFileName() {
         return vsFileName;
     }
 
-    public static String getOutFileName() {
+    public String getOutFileName() {
         return outFileName;
     }
 
-    public static String getSource() {
+    public String getSource() {
         return source;
     }
 
-    public static String getTab() {
+    public String getTab() {
         return tab;
     }
 
-    public static List<String> getPhenotypeExpressions() {
+    public List<String> getPhenotypeExpressions() {
       return phenotypeExpressions;
     }
 
@@ -204,7 +204,7 @@ public final class Config  {
         }
     }
 
-    public static String configString() {
+    public String configString() {
         return String.format("OMOP_BASE_URL=%s, INPUT_FILE_NAME=%s, VS_FILE_NAME=%s, OUT_FILE_NAME=%s, SOURCE=%s, VS_TAB=%s", omopBaseURL, inputFileName, vsFileName, outFileName, source, tab);
     }
 }

--- a/src/main/java/edu/phema/elm_to_omop/io/ElmReader.java
+++ b/src/main/java/edu/phema/elm_to_omop/io/ElmReader.java
@@ -25,9 +25,9 @@ public class ElmReader {
         super();
     }
 
-    public static Library readElm(String directory, Logger logger) throws IOException, JAXBException
+    public static Library readElm(String directory, String filename, Logger logger) throws IOException, JAXBException
     {
-        File file = new File( directory + Config.getInputFileName());
+        File file = new File( directory + filename);
 
         Library elmContents = null;
 

--- a/src/main/java/edu/phema/elm_to_omop/io/OmopWriter.java
+++ b/src/main/java/edu/phema/elm_to_omop/io/OmopWriter.java
@@ -23,8 +23,8 @@ public class OmopWriter {
      * Makes sure the json has been created and writes it to file designated in the configuration
      * Returns the json string
      */
-    public String writeOmopJson(ExpressionDef expression, Library elmContents, java.util.List<ConceptSet> conceptSets, String directory) throws Exception {
-        String jsonFileName = directory + Config.getOutFileName();
+    public String writeOmopJson(ExpressionDef expression, Library elmContents, java.util.List<ConceptSet> conceptSets, String directory, String filename) throws Exception {
+        String jsonFileName = directory + filename;
         try (FileWriter jsonFile = new FileWriter(jsonFileName)) {
             String json = generateOmopJson(expression, elmContents, conceptSets);
 


### PR DESCRIPTION
This PR makes the config non-static, so we can run translation requests multiple times with different configurations as web service requests.