### PR TITLE
👋🏻 Introduce phenotype abstraction

### DIFF
--- a/src/main/java/edu/phema/elm_to_omop/io/ElmReader.java
+++ b/src/main/java/edu/phema/elm_to_omop/io/ElmReader.java
@@ -25,9 +25,8 @@ public class ElmReader {
         super();
     }
 
-    public static Library readElm(String directory, String filename, Logger logger) throws IOException, JAXBException
-    {
-        File file = new File( directory + filename);
+    public static Library readElm(String directory, String filename, Logger logger) throws IOException, JAXBException {
+        File file = new File(directory + filename);
 
         Library elmContents = null;
 
@@ -38,26 +37,33 @@ public class ElmReader {
             elmContents = CqlTranslator.fromFile(file, modelManager, new LibraryManager(modelManager)).toELM();
             String tmp = CqlTranslator.fromFile(file, modelManager, new LibraryManager(modelManager)).toXml();
             System.out.println(tmp);
-        }
-        else {
+        } else {
             elmContents = readXml(file);
         }
 
-        return elmContents;      
+        return elmContents;
     }
-    
-    public static Library readXml(File file) throws JAXBException 
-    {
+
+    public static Library readCqlFile(File file) throws IOException {
+        ModelManager modelManager = new ModelManager();
+        return CqlTranslator.fromFile(file, modelManager, new LibraryManager(modelManager)).toELM();
+    }
+
+    public static Library readCqlString(String cql) {
+        ModelManager modelManager = new ModelManager();
+        return CqlTranslator.fromText(cql, modelManager, new LibraryManager(modelManager)).toELM();
+    }
+
+    public static Library readXml(File file) throws JAXBException {
         Library elmContents = null;
-        
+
         try {
             JAXBContext jaxbContext = CqlTranslator.getJaxbContext();
 
             Unmarshaller jaxbUnmarshaller = jaxbContext.createUnmarshaller();
             JAXBElement<Library> library = jaxbUnmarshaller.unmarshal(new StreamSource(file), Library.class);
             elmContents = library.getValue();
-        }
-        catch (JAXBException e) { 
+        } catch (JAXBException e) {
             throw new JAXBException("Error while parsing the xml - " + e);
         }
         return elmContents;

--- a/src/main/java/edu/phema/elm_to_omop/phenotype/FilePhenotype.java
+++ b/src/main/java/edu/phema/elm_to_omop/phenotype/FilePhenotype.java
@@ -1,0 +1,86 @@
+package edu.phema.elm_to_omop.phenotype;
+
+import edu.phema.elm_to_omop.io.ElmReader;
+import org.hl7.elm.r1.ExpressionDef;
+import org.hl7.elm.r1.Library;
+
+import java.io.File;
+import java.util.List;
+import java.util.Scanner;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+
+public class FilePhenotype implements IPhenotype {
+    private String phenotypeCql;
+    private Library phenotypeElm;
+    private List<String> phenotypeExpressionNames;
+
+    public FilePhenotype(String phenotypeFilePath, List<String> phenotypeExpressionNames) throws PhenotypeException {
+        Logger logger = Logger.getLogger(getClass().getName());
+
+        this.phenotypeExpressionNames = phenotypeExpressionNames;
+
+        if (phenotypeExpressionNames == null || phenotypeExpressionNames.size() == 0) {
+            throw new PhenotypeException("No phenotype expression names specified");
+        }
+
+        if (phenotypeFilePath.endsWith(".cql")) {
+
+            File file = new File(phenotypeFilePath);
+            StringBuilder builder = new StringBuilder();
+
+            try {
+                Scanner scanner = new Scanner(file);
+                while (scanner.hasNextLine()) {
+                    builder.append(scanner.nextLine()).append(System.lineSeparator());
+                }
+            } catch (Exception e) {
+                throw new PhenotypeException("Error reading phenotype file", e);
+            }
+
+            phenotypeCql = builder.toString();
+            phenotypeElm = ElmReader.readCqlString(phenotypeCql);
+        } else {
+            phenotypeCql = null;
+
+            try {
+                phenotypeElm = ElmReader.readElm("", phenotypeFilePath, logger);
+            } catch (Exception e) {
+                throw new PhenotypeException("Error reading phenotype ELM", e);
+            }
+        }
+    }
+
+    @Override
+    public List<ExpressionDef> getPhenotypeExpressions() {
+        return phenotypeElm.getStatements().getDef().stream()
+            .filter(x -> phenotypeExpressionNames.contains(x.getName()))
+            .collect(Collectors.toList());
+    }
+
+    @Override
+    public String getPhenotypeCql() {
+        return phenotypeCql;
+    }
+
+    public void setPhenotypeCql(String phenotypeCql) {
+        this.phenotypeCql = phenotypeCql;
+    }
+
+    @Override
+    public Library getPhenotypeElm() {
+        return phenotypeElm;
+    }
+
+    public void setPhenotypeElm(Library phenotypeElm) {
+        this.phenotypeElm = phenotypeElm;
+    }
+
+    public List<String> getPhenotypeExpressionNames() {
+        return phenotypeExpressionNames;
+    }
+
+    public void setPhenotypeExpressionNames(List<String> phenotypeExpressionNames) {
+        this.phenotypeExpressionNames = phenotypeExpressionNames;
+    }
+}

--- a/src/main/java/edu/phema/elm_to_omop/phenotype/IPhenotype.java
+++ b/src/main/java/edu/phema/elm_to_omop/phenotype/IPhenotype.java
@@ -1,0 +1,14 @@
+package edu.phema.elm_to_omop.phenotype;
+
+import org.hl7.elm.r1.ExpressionDef;
+import org.hl7.elm.r1.Library;
+
+import java.util.List;
+
+public interface IPhenotype {
+    public String getPhenotypeCql();
+
+    public Library getPhenotypeElm();
+
+    public List<ExpressionDef> getPhenotypeExpressions();
+}

--- a/src/main/java/edu/phema/elm_to_omop/phenotype/PhenotypeException.java
+++ b/src/main/java/edu/phema/elm_to_omop/phenotype/PhenotypeException.java
@@ -1,0 +1,11 @@
+package edu.phema.elm_to_omop.phenotype;
+
+public class PhenotypeException extends Exception {
+    public PhenotypeException(String message) {
+        super(message);
+    }
+
+    public PhenotypeException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}


### PR DESCRIPTION
This PR introduces the phenotype abstraction, which right now consists of an ELM library and optionally the CQL source, as well as the list of expression names that comprise the phenotype definitions. I've also implemented the default `FilePhenotype`, which just reads ELM or CQL from a file for parity with what we had.