### PR TITLE
😸 Proposed fix for broken test cases

### DIFF
--- a/src/main/java/edu/phema/elm_to_omop/translate/PhemaElmToOmopTranslator.java
+++ b/src/main/java/edu/phema/elm_to_omop/translate/PhemaElmToOmopTranslator.java
@@ -323,32 +323,34 @@ public class PhemaElmToOmopTranslator {
         String elemName = "";
 
         ListType opType = null;
-        if(expression instanceof Exists) {
+        if (expression instanceof Exists) {
             Expression op = ((Exists) expression).getOperand();
             opType = (ListType) op.getResultType();
             ClassType elemType = (ClassType) opType.getElementType();
             elemName = elemType.getName();
-        }
-        else  {
+        } else {
             elemName = "Condition";
-;       }
+            ;
+        }
 
-        // TODO - Need to map between QDM/FHIR and OHDSI types
-        if(elemName.contains("Condition")) {
-            criteria = new org.ohdsi.circe.cohortdefinition.ConditionOccurrence();
+        // Mappings implemented from: http://build.fhir.org/ig/HL7/cdmh/profiles.html#omop-to-fhir-mappings
+        if (elemName.contains("Condition")) {
+            criteria = new ConditionOccurrence();
             ((ConditionOccurrence) criteria).codesetId = conceptSet.id;
+        } else if (elemName.contains("Procedure")) {
+            criteria = new ProcedureOccurrence();
+            ((ProcedureOccurrence) criteria).codesetId = conceptSet.id;
+        } else if (elemName.contains("MedicationStatement")) {
+            criteria = new DrugExposure();
+            ((DrugExposure) criteria).codesetId = conceptSet.id;
+        }
 
-            if (corelatedCriteria != null) {
-                criteria.CorrelatedCriteria = corelatedCriteria;
-            }
+        // TODO: Implement the reset of the mappings and criteria beyond `codesetId`.
+
+        if (corelatedCriteria != null) {
+            criteria.CorrelatedCriteria = corelatedCriteria;
         }
-        else if(elemName.contains("Procedure")) {
-            criteria = new org.ohdsi.circe.cohortdefinition.ProcedureOccurrence();
-        }
-        else if(elemName.contains("MedicationStatement")) {
-            // no no no....
-            criteria = new org.ohdsi.circe.cohortdefinition.Observation();
-        }
+
         return criteria;
     }
 

--- a/src/test/java/edu/phema/elm_to_omop/translate/PhemaElmToOmopTranslatorTest.java
+++ b/src/test/java/edu/phema/elm_to_omop/translate/PhemaElmToOmopTranslatorTest.java
@@ -306,28 +306,30 @@ class PhemaElmToOmopTranslatorTest {
 
     @Test
     void translateFhirToOhdsi_MedicationStatement() throws Exception {
-      ExpressionDef expression = PhemaElmToOmopTranslator.getExpressionDefByName(library, "MedicationStatementTest");
-      CohortExpression ce = PhemaElmToOmopTranslator.generateCohortExpression(library, expression, conceptSets);
-      List<org.ohdsi.circe.cohortdefinition.InclusionRule> rules = ce.inclusionRules;
-      assertNotNull(rules);
-      assertEquals(1, rules.size());
-      //TODO - This assertion fails until translation code is implemented
-//      PhemaTestHelper.assertStringsEqualIgnoreWhitespace(
-//        PhemaTestHelper.getFileAsString("translated/MedicationStatementTest.json"),
-//        PhemaTestHelper.getJson(rules.get(0)));
+        ExpressionDef expression = PhemaElmToOmopTranslator.getExpressionDefByName(library, "MedicationStatementTest");
+        CohortExpression ce = PhemaElmToOmopTranslator.generateCohortExpression(library, expression, conceptSets);
+
+        List<org.ohdsi.circe.cohortdefinition.InclusionRule> rules = ce.inclusionRules;
+        assertNotNull(rules);
+        assertEquals(1, rules.size());
+
+        PhemaTestHelper.assertStringsEqualIgnoreWhitespace(
+            PhemaTestHelper.getFileAsString("translated/MedicationStatementTest.json"),
+            PhemaTestHelper.getJson(ce));
     }
 
     @Test
     void translateFhirToOhdsi_Procedure() throws Exception {
-      ExpressionDef expression = PhemaElmToOmopTranslator.getExpressionDefByName(library, "ProcedureTest");
-      CohortExpression ce = PhemaElmToOmopTranslator.generateCohortExpression(library, expression, conceptSets);
-      List<org.ohdsi.circe.cohortdefinition.InclusionRule> rules = ce.inclusionRules;
-      assertNotNull(rules);
-      assertEquals(1, rules.size());
-      //TODO - This assertion fails until translation code is implemented
-//      PhemaTestHelper.assertStringsEqualIgnoreWhitespace(
-//        PhemaTestHelper.getFileAsString("translated/ProcedureTest.json"),
-//        PhemaTestHelper.getJson(rules.get(0)));
+        ExpressionDef expression = PhemaElmToOmopTranslator.getExpressionDefByName(library, "ProcedureTest");
+        CohortExpression ce = PhemaElmToOmopTranslator.generateCohortExpression(library, expression, conceptSets);
+
+        List<org.ohdsi.circe.cohortdefinition.InclusionRule> rules = ce.inclusionRules;
+        assertNotNull(rules);
+        assertEquals(1, rules.size());
+
+        PhemaTestHelper.assertStringsEqualIgnoreWhitespace(
+            PhemaTestHelper.getFileAsString("translated/ProcedureTest.json"),
+            PhemaTestHelper.getJson(ce));
     }
 
     @Test

--- a/src/test/resources/translated/MedicationStatementTest.json
+++ b/src/test/resources/translated/MedicationStatementTest.json
@@ -1,32 +1,11 @@
 {
-  "ConceptSets": [
-    {
-      "id": 0,
-      "name": "Statin",
-      "expression": {
-        "items": [
-          {
-            "concept": {
-              "CONCEPT_CLASS_ID": "Clinical Dose Group",
-              "CONCEPT_CODE": "1158285",
-              "CONCEPT_ID": 36223225,
-              "CONCEPT_NAME": "atorvastatin Pill",
-              "DOMAIN_ID": "Drug",
-              "INVALID_REASON": "V",
-              "INVALID_REASON_CAPTION": "Valid",
-              "STANDARD_CONCEPT": "C",
-              "STANDARD_CONCEPT_CAPTION": "Classification",
-              "VOCABULARY_ID": "RxNorm"
-            }
-          }
-        ]
-      }
-    }
-  ],
+  "Title": "MedicationStatementTest",
   "PrimaryCriteria": {
     "CriteriaList": [
       {
-        "VisitOccurrence": {}
+        "VisitOccurrence": {
+          "VisitTypeExclude": false
+        }
       }
     ],
     "ObservationWindow": {
@@ -37,6 +16,73 @@
       "Type": "First"
     }
   },
+  "ConceptSets": [
+    {
+      "id": 0,
+      "name": "Diabetes",
+      "expression": {
+        "items": [
+          {
+            "isExcluded": false,
+            "includeDescendants": false,
+            "includeMapped": false
+          }
+        ]
+      }
+    },
+    {
+      "id": 1,
+      "name": "Hypertension",
+      "expression": {
+        "items": [
+          {
+            "isExcluded": false,
+            "includeDescendants": false,
+            "includeMapped": false
+          }
+        ]
+      }
+    },
+    {
+      "id": 2,
+      "name": "Atrial Fibrilation",
+      "expression": {
+        "items": [
+          {
+            "isExcluded": false,
+            "includeDescendants": false,
+            "includeMapped": false
+          }
+        ]
+      }
+    },
+    {
+      "id": 3,
+      "name": "Statin VS",
+      "expression": {
+        "items": [
+          {
+            "isExcluded": false,
+            "includeDescendants": false,
+            "includeMapped": false
+          }
+        ]
+      }
+    },
+    {
+      "id": 4,
+      "name": "Colonoscopy VS",
+      "expression": {
+        "items": [
+          {
+            "isExcluded": false,
+            "includeDescendants": false,
+            "includeMapped": false
+          }
+        ]
+      }
+    }
+  ],
   "QualifiedLimit": {
     "Type": "First"
   },
@@ -46,13 +92,15 @@
   "InclusionRules": [
     {
       "name": "MedicationStatementTest",
+      "description": "MedicationStatementTest",
       "expression": {
         "Type": "ALL",
         "CriteriaList": [
           {
             "Criteria": {
               "DrugExposure": {
-                "CodesetId": 0
+                "CodesetId": 3,
+                "DrugTypeExclude": false
               }
             },
             "StartWindow": {
@@ -65,8 +113,10 @@
             },
             "Occurrence": {
               "Type": 2,
-              "Count": 1
-            }
+              "Count": 1,
+              "IsDistinct": false
+            },
+            "RestrictVisit": false
           }
         ],
         "DemographicCriteriaList": [],
@@ -74,10 +124,8 @@
       }
     }
   ],
-  "CensoringCriteria": [],
   "CollapseSettings": {
     "CollapseType": "ERA",
     "EraPad": 0
-  },
-  "CensorWindow": {}
+  }
 }

--- a/src/test/resources/translated/ProcedureTest.json
+++ b/src/test/resources/translated/ProcedureTest.json
@@ -1,13 +1,106 @@
-
+{
+  "Title": "ProcedureTest",
+  "PrimaryCriteria": {
+    "CriteriaList": [
+      {
+        "VisitOccurrence": {
+          "VisitTypeExclude": false
+        }
+      }
+    ],
+    "ObservationWindow": {
+      "PriorDays": 0,
+      "PostDays": 0
+    },
+    "PrimaryCriteriaLimit": {
+      "Type": "First"
+    }
+  },
+  "ConceptSets": [
+    {
+      "id": 0,
+      "name": "Diabetes",
+      "expression": {
+        "items": [
+          {
+            "isExcluded": false,
+            "includeDescendants": false,
+            "includeMapped": false
+          }
+        ]
+      }
+    },
+    {
+      "id": 1,
+      "name": "Hypertension",
+      "expression": {
+        "items": [
+          {
+            "isExcluded": false,
+            "includeDescendants": false,
+            "includeMapped": false
+          }
+        ]
+      }
+    },
+    {
+      "id": 2,
+      "name": "Atrial Fibrilation",
+      "expression": {
+        "items": [
+          {
+            "isExcluded": false,
+            "includeDescendants": false,
+            "includeMapped": false
+          }
+        ]
+      }
+    },
+    {
+      "id": 3,
+      "name": "Statin VS",
+      "expression": {
+        "items": [
+          {
+            "isExcluded": false,
+            "includeDescendants": false,
+            "includeMapped": false
+          }
+        ]
+      }
+    },
+    {
+      "id": 4,
+      "name": "Colonoscopy VS",
+      "expression": {
+        "items": [
+          {
+            "isExcluded": false,
+            "includeDescendants": false,
+            "includeMapped": false
+          }
+        ]
+      }
+    }
+  ],
+  "QualifiedLimit": {
+    "Type": "First"
+  },
+  "ExpressionLimit": {
+    "Type": "First"
+  },
+  "InclusionRules": [
     {
       "name": "ProcedureTest",
+      "description": "ProcedureTest",
       "expression": {
         "Type": "ALL",
         "CriteriaList": [
           {
             "Criteria": {
               "ProcedureOccurrence": {
-                "CodesetId": 0
+                "CodesetId": 4,
+                "ProcedureTypeExclude": false
               }
             },
             "StartWindow": {
@@ -20,12 +113,19 @@
             },
             "Occurrence": {
               "Type": 2,
-              "Count": 1
-            }
+              "Count": 1,
+              "IsDistinct": false
+            },
+            "RestrictVisit": false
           }
         ],
         "DemographicCriteriaList": [],
         "Groups": []
       }
     }
-
+  ],
+  "CollapseSettings": {
+    "CollapseType": "ERA",
+    "EraPad": 0
+  }
+}


### PR DESCRIPTION
This is what I think needs to be done to fix the broken test cases. These were the issues that I could see:

  1. The expected JSON responses did not include default values for primitives as discussed in #20
  2. The `codesetId` was not set in the Java
  3. The wrong `codesetId` value was in the expected JSON (our test CQL has 5 valuesets)
  4. `MedicationStatement` maps to `DrugExposure` (based on [these](http://build.fhir.org/ig/HL7/cdmh/profiles.html#omop-to-fhir-mappings) mappings)