### PR TITLE
Remove dependency on files relative to src/main/resources

### DIFF
--- a/config/config.properties
+++ b/config/config.properties
@@ -1,9 +1,9 @@
 #relative to the resources directory
 # Can test toggling between CQL and ELM (XML) results
 #INPUT_FILE_NAME=diabetes/simple-dx.cql
-INPUT_FILE_NAME=diabetes/simple-dx-elm.xml
+INPUT_FILE_NAME=src/main/resources/diabetes/simple-dx-elm.xml
 
-VS_FILE_NAME=diabetes/diabetes.csv
+VS_FILE_NAME=src/main/resources/diabetes/diabetes.csv
 VS_TAB=diabetes
 
 #phema test instance
@@ -16,4 +16,4 @@ SOURCE=OHDSI-CDMV5
 
 PHENOTYPE_EXPRESSIONS=In Initial Population
 
-OUT_FILE_NAME=ohdsiCohortDefinition.json
+OUT_FILE_NAME=src/main/resources/diabetes-ohdsi-definition.json

--- a/src/main/java/edu/phema/elm_to_omop/ElmToOmopConverter.java
+++ b/src/main/java/edu/phema/elm_to_omop/ElmToOmopConverter.java
@@ -18,7 +18,6 @@ import org.ohdsi.webapi.cohortdefinition.InclusionRuleReport;
 import org.ohdsi.webapi.service.CohortDefinitionService.CohortDefinitionDTO;
 
 import javax.xml.bind.JAXBException;
-import java.io.File;
 import java.io.IOException;
 import java.util.List;
 import java.util.logging.FileHandler;
@@ -45,10 +44,10 @@ public class ElmToOmopConverter {
     public static void main(String[] args) {
         ElmToOmopConverter converter = new ElmToOmopConverter();
 
-        converter.run(args, getResourceDirectory());
+        converter.run(args);
     }
 
-    public void run(String[] args, String resourceDirectory) {
+    public void run(String[] args) {
         try {
             // Setup configuration
             Config config;
@@ -72,10 +71,10 @@ public class ElmToOmopConverter {
             // 1. Determine if the user has specified which expression(s) is/are the phenotype definitions of interest.
             //    the CQL/ELM can be vague if not explicitly defined otherwise.
             // 2. Read the elm file and set up the objects
-            FilePhenotype phenotype = new FilePhenotype(resourceDirectory + config.getInputFileName(), config.getPhenotypeExpressions());
+            FilePhenotype phenotype = new FilePhenotype(config.getInputFileName(), config.getPhenotypeExpressions());
 
             // read the value set csv and add to the objects
-            SpreadsheetValuesetService valuesetService = new SpreadsheetValuesetService(omopService, resourceDirectory + config.getVsFileName(), config.getTab());
+            SpreadsheetValuesetService valuesetService = new SpreadsheetValuesetService(omopService, config.getVsFileName(), config.getTab());
 
             List<PhemaConceptSet> conceptSets = valuesetService.getConceptSets();
 
@@ -102,7 +101,7 @@ public class ElmToOmopConverter {
             }
 
             // Write the resulting cohort definitions to out to the filesystem
-            omopWriter.writeOmopJson(cohortDefinitions, resourceDirectory, config.getOutFileName());
+            omopWriter.writeOmopJson(cohortDefinitions, config.getOutFileName());
         } catch (PhenotypeException pe) {
             System.out.println(pe.getMessage());
             pe.printStackTrace();
@@ -125,15 +124,5 @@ public class ElmToOmopConverter {
         logger.addHandler(fh);
         fh.setFormatter(new MyFormatter());
         return fh;
-    }
-
-    private static String getResourceDirectory() {
-        String workingDir = System.getProperty("user.dir");
-
-        if (!workingDir.endsWith("src" + File.separator + "main")) {
-            workingDir += File.separator + "src" + File.separator + "main";
-        }
-
-        return workingDir + File.separator + "resources" + File.separator;
     }
 }

--- a/src/main/java/edu/phema/elm_to_omop/io/OmopWriter.java
+++ b/src/main/java/edu/phema/elm_to_omop/io/OmopWriter.java
@@ -26,8 +26,7 @@ public class OmopWriter {
      * Makes sure the json has been created and writes it to file designated in the configuration
      * Returns the json string
      */
-    public String writeOmopJson(ExpressionDef expression, Library elmContents, List<PhemaConceptSet> conceptSets, String directory, String filename) throws Exception {
-        String jsonFileName = directory + filename;
+    public String writeOmopJson(ExpressionDef expression, Library elmContents, List<PhemaConceptSet> conceptSets, String jsonFileName) throws Exception {
         try (FileWriter jsonFile = new FileWriter(jsonFileName)) {
             String json = generateOmopJson(expression, elmContents, conceptSets);
 
@@ -41,11 +40,9 @@ public class OmopWriter {
      * Serializes a list Circe cohort definitions to a file
      *
      * @param cohortDefinitions The cohort definitions
-     * @param directory         The directory to write the file to
-     * @param filename          The filename
+     * @param jsonFileName      The filename
      */
-    public void writeOmopJson(List<CohortDefinitionDTO> cohortDefinitions, String directory, String filename) {
-        String jsonFileName = directory + filename;
+    public void writeOmopJson(List<CohortDefinitionDTO> cohortDefinitions, String jsonFileName) {
         try (FileWriter jsonFile = new FileWriter(jsonFileName)) {
             ObjectMapper mapper = new ObjectMapper();
             mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);

--- a/src/main/java/edu/phema/elm_to_omop/io/SpreadsheetReader.java
+++ b/src/main/java/edu/phema/elm_to_omop/io/SpreadsheetReader.java
@@ -22,16 +22,8 @@ public class SpreadsheetReader {
     public ArrayList<PhemaValueSet> getSpreadsheetData(String patientFileLoc, String sheetName) throws FileNotFoundException, InvalidFormatException, IOException {
         ArrayList<PhemaValueSet> valueSets = new ArrayList<PhemaValueSet>();
 
-        InputStream in;
         try {
-            // First try to read file as resource
-            in = SpreadsheetReader.class.getResourceAsStream(patientFileLoc);
-
-            // If that doesn't work, try as file
-            if (in == null) {
-                in = new FileInputStream(patientFileLoc);
-            }
-
+            InputStream in = new FileInputStream(patientFileLoc);
             Reader reader = new BufferedReader(new InputStreamReader(in));
             CSVParser csvParser = new CSVParser(reader, CSVFormat.DEFAULT);
             valueSets = readSheet(csvParser, sheetName);

--- a/src/test/java/CliTest.java
+++ b/src/test/java/CliTest.java
@@ -67,22 +67,22 @@ public class CliTest {
 
     @Test
     public void CliTest() throws Exception {
-        String[] args = new String[]{
-            "OMOP_BASE_URL=http://localhost:53333/",
-            "VS_FILE_NAME=/cli/simple.csv",
-            "INPUT_FILE_NAME=/cli/simple.cql",
-            "OUT_FILE_NAME=/cli/simple.omop.json",
-            "SOURCE=phema-test",
-            "PHENOTYPE_EXPRESSIONS=CliTest"
-        };
-
         try {
             ElmToOmopConverter converter = new ElmToOmopConverter();
 
             URL resource = getClass().getResource("LibraryHelperTests.cql");
             File file = Paths.get(resource.toURI()).toFile();
 
-            converter.run(args, file.getParent());
+            String[] args = new String[]{
+              "OMOP_BASE_URL=http://localhost:53333/",
+              String.format("VS_FILE_NAME=%s", PhemaTestHelper.getResourcePath("cli/simple.csv")),
+              String.format("INPUT_FILE_NAME=%s", PhemaTestHelper.getResourcePath("cli/simple.cql")),
+              String.format("OUT_FILE_NAME=%s/cli/simple.omop.json", file.getParent()),
+              "SOURCE=phema-test",
+              "PHENOTYPE_EXPRESSIONS=CliTest"
+            };
+
+          converter.run(args);
 
             PhemaTestHelper.assertStringsEqualIgnoreWhitespace(
                 PhemaTestHelper.getFileAsString("cli/simple-expected.omop.json"),

--- a/src/test/java/edu/phema/elm_to_omop/api/CohortServiceTest.java
+++ b/src/test/java/edu/phema/elm_to_omop/api/CohortServiceTest.java
@@ -58,7 +58,7 @@ public class CohortServiceTest {
 
         omopRepository = new OmopRepositoryService("http://localhost:53333/", "phema-test");
 
-        String vsPath = "/api/valuesets/simple.csv";
+        String vsPath = PhemaTestHelper.getResourcePath("api/valuesets/simple.csv");
         valuesetService = new SpreadsheetValuesetService(omopRepository, vsPath, "simple");
     }
 

--- a/src/test/java/edu/phema/elm_to_omop/api/ElmToOmopTranslatorTest.java
+++ b/src/test/java/edu/phema/elm_to_omop/api/ElmToOmopTranslatorTest.java
@@ -42,7 +42,7 @@ public class ElmToOmopTranslatorTest {
 
         omopRepository = new OmopRepositoryService("http://localhost:53333/", "phema-test");
 
-        String vsPath = "/api/valuesets/simple.csv";
+        String vsPath = PhemaTestHelper.getResourcePath("api/valuesets/simple.csv");
         valuesetService = new SpreadsheetValuesetService(omopRepository, vsPath, "simple");
     }
 

--- a/src/test/java/edu/phema/elm_to_omop/criteria/AgeCriteriaTest.java
+++ b/src/test/java/edu/phema/elm_to_omop/criteria/AgeCriteriaTest.java
@@ -40,7 +40,7 @@ public class AgeCriteriaTest {
 
         lenient().when(omopRepository.getConceptMetadata("1.2.3.4")).thenReturn(new Concept());
 
-        String vsPath = "/LibraryHelperTests.csv";
+        String vsPath = PhemaTestHelper.getResourcePath("LibraryHelperTests.csv");
         valuesetService = new SpreadsheetValuesetService(omopRepository, vsPath, "simple");
 
         ModelManager modelManager = new ModelManager();

--- a/src/test/java/edu/phema/elm_to_omop/phenotype/FilePhenotypeTest.java
+++ b/src/test/java/edu/phema/elm_to_omop/phenotype/FilePhenotypeTest.java
@@ -32,7 +32,7 @@ public class FilePhenotypeTest {
 
         lenient().when(omopRepository.getConceptMetadata("1.2.3.4")).thenReturn(new Concept());
 
-        String vsPath = "/LibraryHelperTests.csv";
+        String vsPath = PhemaTestHelper.getResourcePath("LibraryHelperTests.csv");
         valuesetService = new SpreadsheetValuesetService(omopRepository, vsPath, "simple");
 
         conceptSets = valuesetService.getConceptSets();

--- a/src/test/java/edu/phema/elm_to_omop/translate/PhemaElmToOmopTranslatorTest.java
+++ b/src/test/java/edu/phema/elm_to_omop/translate/PhemaElmToOmopTranslatorTest.java
@@ -51,7 +51,7 @@ class PhemaElmToOmopTranslatorTest {
 
         lenient().when(omopRepository.getConceptMetadata("1.2.3.4")).thenReturn(new Concept());
 
-        String vsPath = "/LibraryHelperTests.csv";
+        String vsPath = PhemaTestHelper.getResourcePath("LibraryHelperTests.csv");
         valuesetService = new SpreadsheetValuesetService(omopRepository, vsPath, "simple");
 
         ModelManager modelManager = new ModelManager();

--- a/src/test/java/edu/phema/elm_to_omop/vocabulary/ConceptCodeCsvFileValuesetServiceTest.java
+++ b/src/test/java/edu/phema/elm_to_omop/vocabulary/ConceptCodeCsvFileValuesetServiceTest.java
@@ -45,7 +45,7 @@ public class ConceptCodeCsvFileValuesetServiceTest {
     @Test
     public void test() throws Exception {
         // Test simple case with one terminology where all codes exists
-        valuesetService = new ConceptCodeCsvFileValuesetService(omopRepository, "/vocabulary/icd9-only.csv");
+        valuesetService = new ConceptCodeCsvFileValuesetService(omopRepository, PhemaTestHelper.getResourcePath("vocabulary/icd9-only.csv"));
         PhemaConceptSetList concepts = valuesetService.getConceptSetList();
 
         assertEquals(concepts.getConceptSets().size(), 1);
@@ -53,7 +53,7 @@ public class ConceptCodeCsvFileValuesetServiceTest {
         assertEquals(concepts.getNotFoundCodes().size(), 0);
 
         // Test two terminologies where all codes exists
-        valuesetService = new ConceptCodeCsvFileValuesetService(omopRepository, "/vocabulary/icd9-and-icd10.csv");
+        valuesetService = new ConceptCodeCsvFileValuesetService(omopRepository, PhemaTestHelper.getResourcePath("vocabulary/icd9-and-icd10.csv"));
         concepts = valuesetService.getConceptSetList();
 
         assertEquals(concepts.getConceptSets().size(), 1);
@@ -61,7 +61,7 @@ public class ConceptCodeCsvFileValuesetServiceTest {
         assertEquals(concepts.getNotFoundCodes().size(), 0);
 
         // Test two terminologies where some codes don't exist
-        valuesetService = new ConceptCodeCsvFileValuesetService(omopRepository, "/vocabulary/icd9-and-icd10-and-missing.csv");
+        valuesetService = new ConceptCodeCsvFileValuesetService(omopRepository, PhemaTestHelper.getResourcePath("vocabulary/icd9-and-icd10-and-missing.csv"));
         concepts = valuesetService.getConceptSetList();
 
         assertEquals(concepts.getConceptSets().size(), 1);
@@ -72,7 +72,7 @@ public class ConceptCodeCsvFileValuesetServiceTest {
     @Test
     public void testMultiple() throws Exception {
         // Test loading a directory containing multiple valueset CSV files
-        valuesetService = new ConceptCodeCsvFileValuesetService(omopRepository, "/vocabulary/two-valuesets.valueset.csv");
+        valuesetService = new ConceptCodeCsvFileValuesetService(omopRepository, PhemaTestHelper.getResourcePath("vocabulary/two-valuesets.valueset.csv"));
         PhemaConceptSetList concepts = valuesetService.getConceptSetList();
 
         assertEquals(concepts.getConceptSets().size(), 2);
@@ -84,7 +84,7 @@ public class ConceptCodeCsvFileValuesetServiceTest {
     @Test
     public void testDirectory() throws Exception {
         // Test loading a directory containing multiple valueset CSV files
-        valuesetService = new ConceptCodeCsvFileValuesetService(omopRepository, "/vocabulary");
+        valuesetService = new ConceptCodeCsvFileValuesetService(omopRepository, PhemaTestHelper.getResourcePath("vocabulary"));
         PhemaConceptSetList concepts = valuesetService.getConceptSetList();
 
         PhemaTestHelper.assertStringsEqualIgnoreWhitespace(


### PR DESCRIPTION
In trying to make the executer more portable as a standalone program, I propose we remove the requirement that paths always be relative to `src/main/resources`.  This will allow us to have more intuitive path conventions defined by the users as they set up a directory containing a phenotype.